### PR TITLE
changed browser calls to use general browser

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -132,7 +132,7 @@ STR is the declaration."
 (defun mermaid-open-browser ()
   "Open the current buffer or active region in the mermaid live editor."
   (interactive)
-  (browse-url-default-browser
+  (browse-url
    (concat "https://mermaidjs.github.io/mermaid-live-editor/#/edit/"
            (replace-regexp-in-string "\n" ""
                                      (base64-encode-string
@@ -143,7 +143,7 @@ STR is the declaration."
 (defun mermaid-open-doc ()
   "Open the mermaid home page and doc."
   (interactive)
-  (browse-url-default-browser "https://mermaidjs.github.io/"))
+  (browse-url "https://mermaidjs.github.io/"))
 
 (defvar mermaid-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
I like to use `browse-url-generic` over `browse-url-default-browser`. This is useful for when I want to use arguments like private window likeso:
```lisp
(setq browse-url-generic-args '("-private")
      browse-url-firefox-program "firefox"
      browse-url-generic-program "firefox")
```
However, I realize this is not for everyone and respect some people like to just use `browse-url-default-browser`. The middle ground use `browse-url` I think. It seems to me that this will use the default browser by... default. Or else you can specify it to use the generic program with `(setq browse-url-browser-function 'browse-url-generic)`. 

A small PR, but I went ahead and made the changes necessary.