### PR TITLE
Update mermaid js references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # mermaid-mode
 
-Emacs major mode for working with [mermaid graphs](https://mermaidjs.github.io/)
+Emacs major mode for working with [mermaid graphs](https://mermaid-js.github.io/)
 
 ![Screenshot](./assets/screenshot.jpg "Screenshot")
 
@@ -11,7 +11,7 @@ Emacs major mode for working with [mermaid graphs](https://mermaidjs.github.io/)
 ## Installation
 
 1. Install from Melpa or load the `mermaid-mode.el` file
-1. Install `mmdc` binary from the [mermaid.cli project](https://github.com/mermaidjs/mermaid.cli) if you plan to compile graphs in Emacs
+1. Install `mmdc` binary from the [mermaid-cli project](https://github.com/mermaid-js/mermaid-cli) if you plan to compile graphs in Emacs
 
 ## Usage
 
@@ -29,7 +29,7 @@ Note: All compile commands will open the output in a buffer to view the resultin
 
 ## Customization
 
-You can specify the location of `mmdc` with the variable `mermaid-mmdc-location`, the default assumes you have the binary in your `PATH` (and for that you probably want/need to install [`mermaid.cli`](https://github.com/mermaidjs/mermaid.cli)).
+You can specify the location of `mmdc` with the variable `mermaid-mmdc-location`, the default assumes you have the binary in your `PATH` (and for that you probably want/need to install [`mermaid-cli`](https://github.com/mermaid-js/mermaid-cli)).
 
 By default `mmdc` will compile to png format. You can change that by setting the variable `mermaid-output-format`.
 

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -27,7 +27,7 @@
 ;;; Commentary:
 
 ;; Major mode for working with mermaid graphs.
-;; See https://mermaidjs.github.io/
+;; See https://mermaid-js.github.io/
 
 ;;; Usage:
 
@@ -168,7 +168,7 @@ STR is the declaration."
   "Open the current buffer or active region in the mermaid live editor."
   (interactive)
   (browse-url
-   (concat "https://mermaidjs.github.io/mermaid-live-editor/#/edit/"
+   (concat "https://mermaid-js.github.io/mermaid-live-editor/#/edit/"
            (replace-regexp-in-string "\n" ""
                                      (base64-encode-string
                                       (if (use-region-p)
@@ -178,7 +178,7 @@ STR is the declaration."
 (defun mermaid-open-doc ()
   "Open the mermaid home page and doc."
   (interactive)
-  (browse-url "https://mermaidjs.github.io/"))
+  (browse-url "https://mermaid-js.github.io/"))
 
 (defvar mermaid-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
I haven't used mermaid in a while but started looking at it again for documentation purposes. I guess things have changed, and everything has migrated `mermaidjs` to `mermaid-js`. I _think_ I've made all of the relevant updates here.

Feedback welcome!