### PR TITLE
Fix `mermaid-open-browser` functionality

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -164,16 +164,20 @@ STR is the declaration."
     (apply #'call-process mermaid-mmdc-location nil "*mmdc*" nil (append (split-string mermaid-flags " ") (list "-i" input "-o" output)))
     (display-buffer (find-file-noselect output t))))
 
+(defun mermaid-make-browser-string (diagram)
+  "Create live-editor for the browser."
+  (concat "https://mermaid-js.github.io/mermaid-live-editor/#/edit/"
+          (replace-regexp-in-string "\n" ""
+                                    (base64-encode-string
+                                     (format "{\"code\":%s,\"mermaid\":{\"theme\":\"default\"},\"updateEditor\":false}"
+                                             (json-encode diagram))))))
+
 (defun mermaid-open-browser ()
   "Open the current buffer or active region in the mermaid live editor."
   (interactive)
-  (browse-url
-   (concat "https://mermaid-js.github.io/mermaid-live-editor/#/edit/"
-           (replace-regexp-in-string "\n" ""
-                                     (base64-encode-string
-                                      (if (use-region-p)
-                                          (buffer-substring-no-properties (region-beginning) (region-end))
-                                        (buffer-string)))))))
+  (browse-url (mermaid-make-browser-string (if (use-region-p)
+                                               (buffer-substring-no-properties (region-beginning) (region-end))
+                                             (buffer-string)))))
 
 (defun mermaid-open-doc ()
   "Open the mermaid home page and doc."

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -79,7 +79,7 @@
   :type 'string)
 
 (defcustom mermaid-flags ""
-  "Additional flags to pass to the mermaid.cli."
+  "Additional flags to pass to the mermaid-cli."
   :group 'mermaid-mode
   :type 'string)
 

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -164,8 +164,10 @@ STR is the declaration."
     (apply #'call-process mermaid-mmdc-location nil "*mmdc*" nil (append (split-string mermaid-flags " ") (list "-i" input "-o" output)))
     (display-buffer (find-file-noselect output t))))
 
-(defun mermaid-make-browser-string (diagram)
-  "Create live-editor for the browser."
+(defun mermaid--make-browser-string (diagram)
+  "Create live-editor string for browser access.
+
+DIAGRAM is a string of mermaid-js code to be displayed in the live-editor."
   (concat "https://mermaid-js.github.io/mermaid-live-editor/#/edit/"
           (replace-regexp-in-string "\n" ""
                                     (base64-encode-string
@@ -175,7 +177,7 @@ STR is the declaration."
 (defun mermaid-open-browser ()
   "Open the current buffer or active region in the mermaid live editor."
   (interactive)
-  (browse-url (mermaid-make-browser-string (if (use-region-p)
+  (browse-url (mermaid--make-browser-string (if (use-region-p)
                                                (buffer-substring-no-properties (region-beginning) (region-end))
                                              (buffer-string)))))
 


### PR DESCRIPTION
With some of the more _recent_ changes, it looks like the diagram needs to be passed inside a JSON payload to the live-editor. This seems to do the trick. Pardon my lisp.

**n.b.** I just came across the convention of using double-hyphens to identify internal/private/helper functions. While addressing this, I noticed that the previous docstring made little sense and was otherwise incomplete. Mea culpa.