### PR TITLE
define comment variables for `%%` comment strings

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -193,7 +193,10 @@ STR is the declaration."
 ;;;###autoload
 (define-derived-mode mermaid-mode fundamental-mode "mermaid"
   (setq-local font-lock-defaults '(mermaid-font-lock-keywords))
-  (setq-local indent-line-function 'mermaid-indent-line))
+  (setq-local indent-line-function 'mermaid-indent-line)
+  (setq-local comment-start "%%")
+  (setq-local comment-end "")
+  (setq-local comment-start-skip "%%+ *"))
 
 (provide 'mermaid-mode)
 ;;; mermaid-mode.el ends here


### PR DESCRIPTION
Obviously, I'm using mermaid-js a lot recently and this mermaid-mode has been really handy for me! I'm missing features here and there, so I thought it might be nice to allow for commenting, too!

Looking at other packaged modes, it seems like `(set (make-local-variable 'foo) "bar")` is common, instead of comparable macro'd `(setq-local foo "bar")`. I'm not sure what the end difference really is here, but I trust the reviewer will offer corrections as warranted :wink: