### PR TITLE
support highlighting comments

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -186,6 +186,16 @@ DIAGRAM is a string of mermaid-js code to be displayed in the live-editor."
   (interactive)
   (browse-url "https://mermaid-js.github.io/"))
 
+(defvar mermaid-syntax-table nil
+  "Syntax table for `mermaid-mode'.")
+
+(setq mermaid-syntax-table
+      (let ((syn-table (make-syntax-table)))
+        ;; Comment style “%% ...”
+        (modify-syntax-entry ?% ". 124" syn-table)
+        (modify-syntax-entry ?\n ">" syn-table)
+        syn-table))
+
 (defvar mermaid-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") 'mermaid-compile)
@@ -197,7 +207,8 @@ DIAGRAM is a string of mermaid-js code to be displayed in the live-editor."
     map))
 
 ;;;###autoload
-(define-derived-mode mermaid-mode fundamental-mode "mermaid"
+(define-derived-mode mermaid-mode prog-mode "mermaid"
+  :syntax-table mermaid-syntax-table
   (setq-local font-lock-defaults '(mermaid-font-lock-keywords))
   (setq-local indent-line-function 'mermaid-indent-line)
   (setq-local comment-start "%%")

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -88,6 +88,14 @@
     ("---\\|-?->*\\+?\\|==>\\|===" . font-lock-function-name-face)
     (,(regexp-opt '("TB" "TD" "BT" "LR" "RL" "DT" "BT" "class" "title" "section" "participant" "dataFormat" "Note") 'words) . font-lock-constant-face)))
 
+(defvar mermaid-syntax-table
+  (let ((syntax-table (make-syntax-table)))
+    ;; Comment style "%% ..."
+    (modify-syntax-entry ?% ". 124" syntax-table)
+    (modify-syntax-entry ?\n ">" syntax-table)
+    syntax-table)
+  "Syntax table for `mermaid-mode'.")
+
 (defvar org-babel-default-header-args:mermaid
   '((:results . "file") (:exports . "results"))
   "Default arguments for evaluating a mermaid source block.")
@@ -185,16 +193,6 @@ DIAGRAM is a string of mermaid-js code to be displayed in the live-editor."
   "Open the mermaid home page and doc."
   (interactive)
   (browse-url "https://mermaid-js.github.io/"))
-
-(defvar mermaid-syntax-table nil
-  "Syntax table for `mermaid-mode'.")
-
-(setq mermaid-syntax-table
-      (let ((syn-table (make-syntax-table)))
-        ;; Comment style “%% ...”
-        (modify-syntax-entry ?% ". 124" syn-table)
-        (modify-syntax-entry ?\n ">" syn-table)
-        syn-table))
 
 (defvar mermaid-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Hi,

I created a syntax table, which allows `mermaid-mode` to highlight comments, as in the attached screenshot.

![mermaid](https://user-images.githubusercontent.com/193967/165304977-ac957fb7-d81b-40c9-85ef-33fe1eefaf66.png)

Can you consider merging this PR?

Thank you!