### PR TITLE
Use full path for input

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -147,7 +147,7 @@ STR is the declaration."
 (defun mermaid-compile ()
   "Compile the current mermaid file using mmdc."
   (interactive)
-  (mermaid-compile-file (f-filename (buffer-file-name))))
+  (mermaid-compile-file (buffer-file-name)))
 
 (defun mermaid-compile-buffer ()
   "Compile the current mermaid buffer using mmdc."


### PR DESCRIPTION
It would otherwise fail if the `default-directory` value is not the same as the dir in which the file is in.

*I tried to look up any reasoning why we would have had `f-filename` but I was not able to find anything. It was added in the first ever commit to the repository.*