### PR TITLE
Fixing indentation of erDiagram graphs

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -127,9 +127,9 @@ STR is the declaration."
   "Determine the indentation level that this line should have."
   (save-excursion
     (end-of-line)
-    (let ((graph (mermaid--locate-declaration "^graph\\|sequenceDiagram\\|^gantt"))
+    (let ((graph (mermaid--locate-declaration "^graph\\|sequenceDiagram\\|^gantt\\|^erDiagram"))
           (subgraph (mermaid--locate-declaration "subgraph \\|loop \\|alt \\|opt"))
-          (both (mermaid--locate-declaration "^graph \\|^sequenceDiagram$\\|subgraph \\|loop \\|alt \\|opt\\|^gantt"))
+          (both (mermaid--locate-declaration "^graph \\|^sequenceDiagram$\\|subgraph \\|loop \\|alt \\|opt\\|^gantt\\|^erDiagram"))
           (else (mermaid--locate-declaration "else "))
           (end (mermaid--locate-declaration "^ *end *$")))
       (cond ((equal (car graph) 0) 0) ;; this is a graph declaration


### PR DESCRIPTION
We now treat `erDiagram` as a top-level graph declaration, which causes them and their content to be indented properly.