### PR TITLE
Fix a warning and add CI for byte-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, windows-latest]
+                emacs-version:
+                    - 25.3
+                    - 29.4
+        steps:
+            - uses: actions/checkout@v3
+
+            - uses: jcs090218/setup-emacs@master
+              with:
+                  version: ${{ matrix.emacs-version }}
+
+            - uses: ashutoshvarma/setup-ninja@master
+
+            - name: Compilation check
+              run: ninja

--- a/build.ninja
+++ b/build.ninja
@@ -1,0 +1,4 @@
+rule compile_file
+  command = emacs -batch --eval "(setq byte-compile-error-on-warn t)" $args -f batch-byte-compile $in
+
+build mermaid-mode.elc: compile_file mermaid-mode.el

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -188,8 +188,7 @@ STR is the declaration."
     (if (zerop exit-code)
         (let ((buffer (find-file-noselect output t)))
           (display-buffer buffer)
-          (save-excursion
-            (set-buffer buffer)
+          (with-current-buffer buffer
             (auto-revert-mode)))
       (pop-to-buffer "*mmdc*"))))
 


### PR DESCRIPTION
1st commit fixes a warning *(I'm not sure it's present in latest released Emacs, it may be a new on that appeared upstream. Either way…)*.

2nd commit adds CI

-----------

It's worth noting here that CI support in Github isn't done very well. On Gitlab it's usually something that Just Works™, but [when we were adding Github CI for color-identifers-mode](https://github.com/ankurdave/color-identifiers-mode/pull/114), it didn't work for some time, and then it started working, and it's not clear what influences when that happens. But my current assumption based on previous experience is that Github CI will not show up on this PR, but it should start working on the next ones. So I suggest not to worry at this point if you don't see CI attempting to compile this PR, it's just something that happens on Github.