### PR TITLE
Fix empty arg when mermaid-flags is empty

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -184,7 +184,7 @@ STR is the declaration."
   (interactive "fFilename: ")
   (let* ((input file-name)
          (output (concat (file-name-sans-extension input) mermaid-output-format))
-         (exit-code (apply #'call-process mermaid-mmdc-location nil "*mmdc*" nil (append (split-string mermaid-flags " ") (list "-i" input "-o" output)))))
+         (exit-code (apply #'call-process mermaid-mmdc-location nil "*mmdc*" nil (append (split-string mermaid-flags " " t) (list "-i" input "-o" output)))))
     (if (zerop exit-code)
         (let ((buffer (find-file-noselect output t)))
           (display-buffer buffer)


### PR DESCRIPTION
When `mermaid-flags` is empty, when I try to compile mermaid file, I get the following error message from `mmdc`:

```
error: too many arguments. Expected 0 arguments but got 1.
```

This is because `(append (split-string mermaid-flags " ") (list "-i" input "-o" output))` (inside `mermaid-compile-file`) evaluates to `("" "-i" "example.mermaid" "-o" "example.png")`, with the first arg being empty string.

Adding `OMIT-NULLS` argument with value `t` to `split-string` call fixes this.

Reproduced with `mermaid-cli` 11.6.0 installed with `npm install -g` on linux.