### PR TITLE
Rework indentation algo and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
 
             - uses: ashutoshvarma/setup-ninja@master
 
-            - name: Compilation check
-              run: ninja
+            - name: Compile and run tests
+              run: ninja tests

--- a/build.ninja
+++ b/build.ninja
@@ -1,4 +1,19 @@
+rule batch_emacs
+  command = emacs -batch $args
+  pool    = console
+
 rule compile_file
   command = emacs -batch --eval "(setq byte-compile-error-on-warn t)" $args -f batch-byte-compile $in
 
 build mermaid-mode.elc: compile_file mermaid-mode.el
+default mermaid-mode.elc
+
+build tests/mermaid-indentation-tests.elc: compile_file tests/mermaid-indentation-tests.el | mermaid-mode.elc
+  args = -l mermaid-mode.elc
+
+build tests': batch_emacs | mermaid-mode.elc tests/mermaid-indentation-tests.elc
+  args = -l mermaid-mode.elc -l tests/mermaid-indentation-tests.elc -f ert-run-tests-batch-and-exit
+
+# `tests` matches a directory name, but we don't want Ninja to track its
+# timestamp, so instead link `tests` with a non-existing filename.
+build tests: phony tests'

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -88,8 +88,8 @@
   :type 'number)
 
 (defconst mermaid-diagram-starter-keywords
-  '("graph" "classDiagram" "sequenceDiagram" "stateDiagram" "gantt"
-    "erDiagram" "flowchart" "pie")
+  '("graph" "classDiagram" "sequenceDiagram" "stateDiagram" "stateDiagram-v2"
+    "gantt" "erDiagram" "flowchart" "pie")
   "Keywords that start the diagram, typically have indentation of 0.")
 
 (defconst mermaid-diagram-starters-re

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -104,7 +104,7 @@
   (regexp-opt mermaid-branch-starters 'words))
 
 (defconst mermaid-font-lock-keywords
-  `((,(regexp-opt '("graph" "subgraph" "end" "flowchart" "sequenceDiagram" "classDiagram" "stateDiagram" "erDiagram" "gantt" "pie" "loop" "alt" "else" "opt") 'words) . font-lock-keyword-face)
+  `((,(regexp-opt (append mermaid-branch-starters '("end")) 'words) . font-lock-keyword-face)
     ("---\\|-?->*\\+?\\|==>\\|===" . font-lock-function-name-face)
     (,(regexp-opt '("TB" "TD" "BT" "LR" "RL" "DT" "BT" "class" "title" "section" "participant" "actor" "dataFormat" "Note") 'words) . font-lock-constant-face)))
 

--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -87,6 +87,22 @@
   :group 'mermaid-mode
   :type 'number)
 
+(defconst mermaid-diagram-starter-keywords
+  '("graph" "classDiagram" "sequenceDiagram" "stateDiagram" "gantt"
+    "erDiagram" "flowchart" "pie")
+  "Keywords that start the diagram, typically have indentation of 0.")
+
+(defconst mermaid-diagram-starters-re
+  (regexp-opt mermaid-diagram-starter-keywords 'words))
+
+(defconst mermaid-branch-starters
+  (append mermaid-diagram-starter-keywords
+          '("loop" "alt" "else" "opt" "subgraph"))
+  "Keywords that cause next line indentation to increase.")
+
+(defconst mermaid-branch-starters-re
+  (regexp-opt mermaid-branch-starters 'words))
+
 (defconst mermaid-font-lock-keywords
   `((,(regexp-opt '("graph" "subgraph" "end" "flowchart" "sequenceDiagram" "classDiagram" "stateDiagram" "erDiagram" "gantt" "pie" "loop" "alt" "else" "opt") 'words) . font-lock-keyword-face)
     ("---\\|-?->*\\+?\\|==>\\|===" . font-lock-function-name-face)
@@ -125,34 +141,41 @@
     (org-babel-eval cmd "")
     nil))
 
-(defun mermaid--locate-declaration (str)
-  "Locate a certain declaration and return the line difference and indentation.
-
-STR is the declaration."
-  (let ((l (line-number-at-pos)))
-    (save-excursion
-      (if (re-search-backward str (point-min) t)
-          (cons (- l (line-number-at-pos)) (current-indentation))
-        (cons -1 -1)))))
+(defun mermaid--last-noblank-line-indentation ()
+  (save-excursion
+    (if (bobp)
+        0
+      (forward-line -1)
+      (while (and (not (bobp))
+                  (looking-at "[[:blank:]]*$"))
+        (forward-line -1))
+      (back-to-indentation)
+      (+ (current-indentation)
+         (if (looking-at mermaid-branch-starters-re)
+             mermaid-indentation-level
+           0)))))
 
 (defun mermaid--calculate-desired-indentation ()
   "Determine the indentation level that this line should have."
   (save-excursion
-    (end-of-line)
-    (let ((graph (mermaid--locate-declaration "^graph\\|sequenceDiagram\\|^gantt\\|^erDiagram"))
-          (subgraph (mermaid--locate-declaration "subgraph \\|loop \\|alt \\|opt"))
-          (both (mermaid--locate-declaration "^graph \\|^sequenceDiagram$\\|subgraph \\|loop \\|alt \\|opt\\|^gantt\\|^erDiagram"))
-          (else (mermaid--locate-declaration "else "))
-          (end (mermaid--locate-declaration "^ *end *$")))
-      (cond ((equal (car graph) 0) 0) ;; this is a graph declaration
-            ((equal (car end) 0) (cdr subgraph)) ;; this is "end", indent to nearest subgraph
-            ((equal (car subgraph) 0) (+ mermaid-indentation-level (cdr graph))) ;; this is a subgraph
-            ((equal (car else) 0) (cdr subgraph)) ;; this is "else:, indent to nearest alt
-            ;; everything else
-            ((< (car end) 0) (+ mermaid-indentation-level (cdr both))) ;; no end in sight
-            ((< (car both) (car end)) (+ mermaid-indentation-level (cdr both))) ;; (sub)graph declaration closer, +4
-            (t (cdr end)) ;; end declaration closer, same indent
-            ))))
+    (back-to-indentation)
+    (cond
+     ((looking-at mermaid-diagram-starters-re)
+      0)
+
+     ;; A "closer" indentation. We may want to indent it to the corresponding
+     ;; opener. But this would require to count openers over the buffer (e.g. to
+     ;; indent correctly case like `subgraph A\nsubgraph B\nend\nend'), so keep
+     ;; it simple for now — a user probably indented previous line to some value
+     ;; for a reason.
+     ((looking-at (regexp-opt '("end" "else") 'words))
+      (max
+       (- (mermaid--last-noblank-line-indentation) mermaid-indentation-level)
+       0))
+
+     ;; Otherwise assume the previous indentation is okay (whether indented by
+     ;; us or by a user) so indent to it.
+     (t (mermaid--last-noblank-line-indentation)))))
 
 (defun mermaid-indent-line ()
   "Indent the current line."

--- a/tests/mermaid-indentation-tests.el
+++ b/tests/mermaid-indentation-tests.el
@@ -58,7 +58,6 @@ graph TD
     G-->H"))
 
 (ert-deftest mermaid-indent-nested-subgraphs ()
-  :expected-result :failed
   (mermaid-test-indentation
    "
 graph TD
@@ -118,7 +117,6 @@ sequenceDiagram
     end"))
 
 (ert-deftest mermaid-indent-nested-alt-in-loop ()
-  :expected-result :failed
   (mermaid-test-indentation
    "
 sequenceDiagram
@@ -204,7 +202,6 @@ sequenceDiagram
 
 (ert-deftest mermaid-invalid-closer ()
   "Indenting invalid buffer should not cause errors"
-  :expected-result :failed
   (mermaid-test-indentation
    "
 end"

--- a/tests/mermaid-indentation-tests.el
+++ b/tests/mermaid-indentation-tests.el
@@ -1,0 +1,212 @@
+;;; mermaid-indentation-tests.el --- mermaid-mode indentation tests -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026, Konstantin Kharlamov
+
+;; This file is NOT part of Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(require 'ert)
+(require 'mermaid-mode)
+
+(defun mermaid-test-indentation (before after)
+  "Test that indenting BEFORE results in AFTER."
+  (with-temp-buffer
+    (insert before)
+    (mermaid-mode)
+    (let ((indent-tabs-mode nil))
+      (indent-region (point-min) (point-max)))
+    (should (string= after (buffer-string)))))
+
+(ert-deftest mermaid-indent-basic-graph ()
+  (mermaid-test-indentation
+   "
+graph TD
+A-->B
+C-->D"
+   "
+graph TD
+    A-->B
+    C-->D"))
+
+(ert-deftest mermaid-indent-single-subgraph ()
+  (mermaid-test-indentation
+   "
+graph TD
+subgraph One
+C-->D
+E-->F
+end
+G-->H"
+   "
+graph TD
+    subgraph One
+        C-->D
+        E-->F
+    end
+    G-->H"))
+
+(ert-deftest mermaid-indent-nested-subgraphs ()
+  :expected-result :failed
+  (mermaid-test-indentation
+   "
+graph TD
+subgraph Outer
+A-->B
+subgraph Inner
+C-->D
+end
+E-->F
+end
+G-->H"
+   "
+graph TD
+    subgraph Outer
+        A-->B
+        subgraph Inner
+            C-->D
+        end
+        E-->F
+    end
+    G-->H"))
+
+(ert-deftest mermaid-indent-sequence-loop ()
+  (mermaid-test-indentation
+   "
+sequenceDiagram
+loop Daily check
+Alice->>Bob: How are you?
+Bob->>Alice: Great!
+end"
+   "
+sequenceDiagram
+    loop Daily check
+        Alice->>Bob: How are you?
+        Bob->>Alice: Great!
+    end"))
+
+(ert-deftest mermaid-indent-sequence-alt-else ()
+  (mermaid-test-indentation
+   "
+sequenceDiagram
+alt Success
+Alice->>Bob: Good
+else Failure
+Alice->>Bob: Bad
+else Unknown
+Alice->>Bob: ?
+end"
+   "
+sequenceDiagram
+    alt Success
+        Alice->>Bob: Good
+    else Failure
+        Alice->>Bob: Bad
+    else Unknown
+        Alice->>Bob: ?
+    end"))
+
+(ert-deftest mermaid-indent-nested-alt-in-loop ()
+  :expected-result :failed
+  (mermaid-test-indentation
+   "
+sequenceDiagram
+loop Main loop
+alt Happy path
+A->>B: Yes
+else Sad path
+A->>B: No
+end
+C->>D: Continue
+end"
+   "
+sequenceDiagram
+    loop Main loop
+        alt Happy path
+            A->>B: Yes
+        else Sad path
+            A->>B: No
+        end
+        C->>D: Continue
+    end"))
+
+(ert-deftest mermaid-indent-open-block ()
+  (mermaid-test-indentation
+   "
+graph TD
+subgraph Open
+A-->B
+C-->D"
+   "
+graph TD
+    subgraph Open
+        A-->B
+        C-->D"))
+
+(ert-deftest mermaid-indent-gantt ()
+  (mermaid-test-indentation
+   "
+gantt
+title Project
+section Planning
+Task1 :a1, 2024-01-01, 30d
+section Execution
+Task2 :after a1, 60d"
+   "
+gantt
+    title Project
+    section Planning
+    Task1 :a1, 2024-01-01, 30d
+    section Execution
+    Task2 :after a1, 60d"))
+
+(ert-deftest mermaid-indent-er ()
+  (mermaid-test-indentation
+   "
+erDiagram
+CUSTOMER ||--o{ ORDER : places
+ORDER ||--|{ LINE-ITEM : contains"
+   "
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains"))
+
+(ert-deftest mermaid-indent-blanks-lines-interjections ()
+  "Blank lines are skipped correctly for indentation calculation."
+  (mermaid-test-indentation
+   "
+sequenceDiagram
+alt One
+
+A->>B: Hi
+
+else Two
+C->>D: Bye"
+   "
+sequenceDiagram
+    alt One
+
+        A->>B: Hi
+
+    else Two
+        C->>D: Bye"))
+
+(ert-deftest mermaid-invalid-closer ()
+  "Indenting invalid buffer should not cause errors"
+  :expected-result :failed
+  (mermaid-test-indentation
+   "
+end"
+   "
+end"))


### PR DESCRIPTION
Rework indentation algorithm to prefer previous indentation

Parsing whole buffer to calculate the current indentation is wasteful
and error-prone. Mermaid evolves and adds new modes support for which
may be absent from the mode yet, so the user may want to apply custom
indentation and the plugin should account for it.

It is very typical in indentation engines for various programming
languages to account for previous indentation, because a user
frequently may have a reason to align previous indentation to
something only they aware of.

The rule of thumb: if a user wants to reindent code prior to the
current line, they can do that explicitly. So calculate current
indentation based on assumption that previous indentation is already
correct.

This also fixes a bug (see tests) where nested subgraphs were indented
linearly instead of increasing indentation; and another one with
negative numbers.

Fixes: https://github.com/abrochard/mermaid-mode/issues/45

-----------

First commit adds indentation tests to make sure further indentation changes wouldn't break anything. At that point 3 tests are broken and are marked as such.

2nd commit reworks indentation algo per discussion in the issue, and that fixes the 3 tests. I also added more diagram-starter keywords that were missed in the older impl. such as `flowchart`. Besides being useful on its own this will also simplify 3rd commit.

3rd is a  keywords deduplication.

---------

Besides regression tests being added in the PR I also tested this algo on a large `graph TD` I have locally. Before this commit attempting to re-indent it results in broken indentation *(due to nested subgraphs bug, see tests 2nd commit)*, after this commit the buffer remains unchanged as expected.
