### PR TITLE
Support colon-based strings highlight in stateDiagram-v2

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -104,7 +104,8 @@
   (regexp-opt mermaid-branch-starters 'words))
 
 (defconst mermaid-font-lock-keywords
-  `((,(regexp-opt (append mermaid-branch-starters '("end")) 'words) . font-lock-keyword-face)
+  `((":\\s-*\\(.+\\)" 1 font-lock-string-face append)
+    (,(regexp-opt (append mermaid-branch-starters '("end")) 'words) . font-lock-keyword-face)
     ("---\\|-?->*\\+?\\|==>\\|===" . font-lock-function-name-face)
     (,(regexp-opt '("TB" "TD" "BT" "LR" "RL" "DT" "BT" "class" "title" "section" "participant" "actor" "dataFormat" "Note") 'words) . font-lock-constant-face)))
 


### PR DESCRIPTION
stateDiagram-v2 has nodes/links descriptions like:

    NodeName: text description
    Node1 --> Node2: link description

Make sure to highlight those as strings.