### PR TITLE
Use `expand-file-name` for tmp file path construction

### DIFF
--- a/mermaid-mode.el
+++ b/mermaid-mode.el
@@ -191,14 +191,14 @@
 (defun mermaid-compile-buffer ()
   "Compile the current mermaid buffer using mmdc."
   (interactive)
-  (let* ((tmp-file-name (concat mermaid-tmp-dir "current-buffer.mmd")))
+  (let* ((tmp-file-name (expand-file-name "current-buffer.mmd" mermaid-tmp-dir)))
     (write-region (point-min) (point-max) tmp-file-name)
     (mermaid-compile-file tmp-file-name)))
 
 (defun mermaid-compile-region ()
   "Compile the current mermaid region using mmdc."
   (interactive)
-  (let* ((tmp-file-name (concat mermaid-tmp-dir "current-region.mmd")))
+  (let* ((tmp-file-name (expand-file-name "current-region.mmd" mermaid-tmp-dir)))
     (when (use-region-p)
       (write-region (region-beginning) (region-end) tmp-file-name)
       (mermaid-compile-file tmp-file-name))))


### PR DESCRIPTION
This PR replaces `concat` with `expand-file-name` to safely join `mermaid-tmp-dir` and filename, handling missing trailing slashes correctly.

```elisp
(concat "/tmp" "foo.mmd")             ; => "/tmpfoo.mmd"
(expand-file-name "foo.mmd" "/tmp")   ; => "/tmp/foo.mmd"
```